### PR TITLE
chore(release): bump version to 0.10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY_NAME=ee
 BUILD_DIR=build
 COVERAGE_DIR=coverage
-VERSION?=0.9.1
+VERSION?=0.10.0
 GIT_COMMIT=$(shell git rev-parse --short HEAD)
 BUILD_TIME=$(shell date -u '+%Y-%m-%d_%H:%M:%S')
 LDFLAGS=-ldflags "-X main.Version=${VERSION} -X main.GitCommit=${GIT_COMMIT} -X main.BuildTime=${BUILD_TIME}"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ee - Environment Variable Manager with Schema Support
 
 [![Go](https://1tt.dev/badge/Go-1.23+-00ADD8.svg?logo=go&logoColor=white)](https://go.dev/)
-[![Version](https://1tt.dev/badge/version-0.9.1-blue.svg)](https://github.com/n1rna/ee-cli/releases)
+[![Version](https://1tt.dev/badge/version-0.10.0-blue.svg)](https://github.com/n1rna/ee-cli/releases)
 [![License](https://1tt.dev/badge/license-MIT-green.svg)](https://github.com/n1rna/ee-cli/blob/main/LICENSE)
 [![AI Skill](https://1tt.dev/badge/AI%20skill-ee%20skill-brightgreen.svg)](#ai-coding-agent-integration)
 [![Platform](https://1tt.dev/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey.svg)](https://github.com/n1rna/ee-cli/releases)

--- a/cmd/ee/main.go
+++ b/cmd/ee/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	version     = "0.9.1"
+	version     = "0.10.0"
 	cfgFile     string
 	globalFlags = struct {
 		debug bool


### PR DESCRIPTION
## Summary

Release prep for **v0.10.0**. Bumps the version string in `cmd/ee/main.go`, the `Makefile` default, and the README version badge.

## Highlights since v0.9.3

- **feat: `ee skill` command** — installs the ee-usage guide for AI coding agents (Claude, Cursor, Copilot, Codex, opencode) (#2)
- **docs: remove outdated `llms.txt`** in favor of the skill (#3)

Minor version bump per SemVer (new feature, backward compatible).

Once merged, tagging `v0.10.0` triggers the release workflow to build binaries and publish the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
